### PR TITLE
bugfix: #26, check for undefined

### DIFF
--- a/lib/editor-background.coffee
+++ b/lib/editor-background.coffee
@@ -724,7 +724,13 @@ module.exports = EditorBackground =
               tokenizedBuffer:attrs.tokenizedBuffer
             }
             for line in attrs.screenLines
-              @drawLine line,attrsForward
+              # editor.displayBuffer is undocumented, it's .splice function
+              # might return an empty array with a non-zero length
+              # Make sure that if that happens, @drawLine doesn't get passed
+              # `undefined` (CoffeeScript happily indexes non-existing array
+              # indices in a `for-in` loop, as the for loop it expands to only
+              # uses the `.length` property to determine the array's domain.)
+              @drawLine line,attrsForward if line?
 
 
   activeEditor:{}


### PR DESCRIPTION
Fixes #26. It's a hacky fix, but since editor.displayBuffer is undocumented, there is no stable way to fix it.

This method is faster, though more specialized, than making sure every element in `editor.displayBuffer` (in the domain `[0, editor.displayBuffer.length]`) actually exists.

Ironically, this bug was introduced by fixing #10.
