### PR TITLE
Rename `initialize` to `initializePackage` on main module

### DIFF
--- a/lib/editor-background.coffee
+++ b/lib/editor-background.coffee
@@ -230,7 +230,7 @@ module.exports = EditorBackground =
         else
             @startYouTube.apply @,[]
 
-    @initialize()
+    @initializePackage()
 
   deactivate: ()->
     if @subs?
@@ -832,7 +832,7 @@ module.exports = EditorBackground =
     #@subs.add atom.workspace.onDidInsertText (text)=>
 
 
-  initialize: ->
+  initializePackage: ->
     @elements.body = qr 'body'
     @elements.workspace = qr 'atom-workspace'
     @elements.editor = null
@@ -906,7 +906,7 @@ module.exports = EditorBackground =
 
       @applyBackground.apply @
     else
-      setTimeout (=>@initialize.apply @),1000
+      setTimeout (=>@initializePackage.apply @),1000
 
   updateBgPos: ->
     conf = @configWnd.get('editor-background')


### PR DESCRIPTION
As of Atom 1.14, any method named `initialize` on the main module of a package will be automatically invoked by Atom before calling `activate`. You can read more about the change in this [pull request to Atom's documentation](https://github.com/atom/flight-manual.atom.io/pull/300/files).

Since your package's `initialize` method wasn't written with this behavior in mind, we've renamed it for you to avoid unexpected breakage.

Atom 1.14 should reach the beta channel in early January 2017 and will be on stable in early February 2017. Please merge and test out this PR before then to prevent issues, and let us know if you have any questions.

Thanks for your contributions to the Atom community! 🙇 

/cc @camel-chased 